### PR TITLE
Ability to check recent user performance added

### DIFF
--- a/src/main/java/app/Main.java
+++ b/src/main/java/app/Main.java
@@ -7,8 +7,11 @@ import javax.swing.JPanel;
 import javax.swing.WindowConstants;
 
 import data_access.APIDataAccessObject;
+import entity.MatchFactory;
 import entity.UserFactory;
 import interface_adapter.ViewManagerModel;
+import interface_adapter.match_lookup.MatchLookupViewModel;
+import view.MatchView;
 import view.SearchView;
 import view.UserView;
 import view.ViewManager;
@@ -33,15 +36,20 @@ public class Main {
 
 		final SearchViewModel searchViewModel = new SearchViewModel();
 		final UserLookupViewModel userLookupViewModel = new UserLookupViewModel();
+		final MatchLookupViewModel matchLookupViewModel = new MatchLookupViewModel();
 
 		final APIDataAccessObject api = new APIDataAccessObject(new UserFactory());
+		final APIDataAccessObject matchApi = new APIDataAccessObject(new MatchFactory());
 
-		final SearchView searchView = SearchUseCaseFactory.create(searchViewModel, userLookupViewModel,
-				viewManagerModel, api, api);
+		final SearchView searchView = SearchUseCaseFactory.create(searchViewModel, userLookupViewModel, matchLookupViewModel,
+				viewManagerModel, api, api, matchApi);
 		views.add(searchView, searchView.getViewName());
 
 		final UserView userView = UserLookupUseCaseFactory.create(viewManagerModel, userLookupViewModel, api);
 		views.add(userView, userView.getViewName());
+
+		final MatchView matchView = MatchLookupUseCaseFactory.create(viewManagerModel, matchLookupViewModel);
+		views.add(matchView, matchView.getViewName());
 
 		viewManagerModel.setState(searchView.getViewName());
 		viewManagerModel.firePropertyChanged();

--- a/src/main/java/app/MatchLookupUseCaseFactory.java
+++ b/src/main/java/app/MatchLookupUseCaseFactory.java
@@ -1,0 +1,13 @@
+package app;
+
+import interface_adapter.ViewManagerModel;
+import interface_adapter.match_lookup.MatchLookupViewModel;
+import view.MatchView;
+
+public class MatchLookupUseCaseFactory {
+    private MatchLookupUseCaseFactory() {}
+
+    public static MatchView create(ViewManagerModel viewManagerModel, MatchLookupViewModel matchLookupViewModel) {
+        return new MatchView(matchLookupViewModel, viewManagerModel);
+    }
+}

--- a/src/main/java/app/SearchUseCaseFactory.java
+++ b/src/main/java/app/SearchUseCaseFactory.java
@@ -1,11 +1,18 @@
 package app;
 
+import interface_adapter.match_lookup.MatchLookupController;
+import interface_adapter.match_lookup.MatchLookupPresenter;
+import interface_adapter.match_lookup.MatchLookupViewModel;
 import interface_adapter.user_lookup.UserLookupController;
 import interface_adapter.user_lookup.UserLookupPresenter;
 import interface_adapter.user_lookup.UserLookupViewModel;
 import use_case.brawler_lookup.BrawlerLookupDataAccessInterface;
 import use_case.brawler_lookup.BrawlerLookupInputBoundary;
 import use_case.brawler_lookup.BrawlerLookupOutputBoundary;
+import use_case.match_lookup.MatchLookupDataAccessInterface;
+import use_case.match_lookup.MatchLookupInputBoundary;
+import use_case.match_lookup.MatchLookupInteractor;
+import use_case.match_lookup.MatchLookupOutputBoundary;
 import use_case.user_lookup.UserLookupOutputBoundary;
 import view.SearchView;
 import interface_adapter.brawler_lookup.BrawlerLookupController;
@@ -22,22 +29,23 @@ public final class SearchUseCaseFactory {
     }
 
     public static SearchView create(
-            SearchViewModel searchViewModel, UserLookupViewModel userViewModel, ViewManagerModel viewManagerModel,
+            SearchViewModel searchViewModel, UserLookupViewModel userViewModel, MatchLookupViewModel matchViewModel, ViewManagerModel viewManagerModel,
             BrawlerLookupDataAccessInterface brawlerDataAccessObject,
-            UserLookupDataAccessInterface userLookupDataAcessObject) {
+            UserLookupDataAccessInterface userLookupDataAccessObject, MatchLookupDataAccessInterface matchLookupDataAccessObject) {
         final BrawlerLookupController brawlerLookupController = createBrawlerLookupUseCase(searchViewModel,
                 brawlerDataAccessObject);
         final UserLookupController userLookupController = createUserLookupUseCase(userViewModel, viewManagerModel,
-                userLookupDataAcessObject);
-        return new SearchView(searchViewModel, brawlerLookupController, userLookupController);
+                userLookupDataAccessObject);
+        final MatchLookupController matchLookupController = createMatchLookupUseCase(matchViewModel, viewManagerModel, matchLookupDataAccessObject);
+        return new SearchView(searchViewModel, brawlerLookupController, userLookupController, matchLookupController);
 
     }
 
     private static BrawlerLookupController createBrawlerLookupUseCase(SearchViewModel searchViewModel,
             BrawlerLookupDataAccessInterface brawlerDataAccessObject) {
-        final BrawlerLookupOutputBoundary brawlerLookupOnputBoundary = new BrawlerLookupPresenter();
+        final BrawlerLookupOutputBoundary brawlerLookupOutputBoundary = new BrawlerLookupPresenter();
         final BrawlerLookupInputBoundary brawlerLookupInteractor = new BrawlerLookupInteractor(brawlerDataAccessObject,
-                brawlerLookupOnputBoundary);
+                brawlerLookupOutputBoundary);
         return new BrawlerLookupController(brawlerLookupInteractor);
     }
 
@@ -50,6 +58,12 @@ public final class SearchUseCaseFactory {
                 userLookupOutputBoundary);
         return new UserLookupController(userLookupInteractor);
 
+    }
+
+    private static MatchLookupController createMatchLookupUseCase(MatchLookupViewModel matchLookupViewModel, ViewManagerModel viewManagerModel, MatchLookupDataAccessInterface matchLookupDataAccessObject) {
+        final MatchLookupOutputBoundary matchLookupOutputBoundary = new MatchLookupPresenter(matchLookupViewModel, viewManagerModel);
+        final MatchLookupInputBoundary matchLookupInteractor = new MatchLookupInteractor(matchLookupDataAccessObject, matchLookupOutputBoundary);
+        return new MatchLookupController(matchLookupInteractor);
     }
 
 }

--- a/src/main/java/data_access/APIDataAccessObject.java
+++ b/src/main/java/data_access/APIDataAccessObject.java
@@ -16,10 +16,11 @@ import io.github.cdimascio.dotenv.Dotenv;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import use_case.match_lookup.MatchLookupDataAccessInterface;
 import use_case.user_lookup.UserLookupDataAccessInterface;
 import use_case.brawler_lookup.BrawlerLookupDataAccessInterface;
 
-public class APIDataAccessObject implements UserLookupDataAccessInterface, BrawlerLookupDataAccessInterface {
+public class APIDataAccessObject implements UserLookupDataAccessInterface, BrawlerLookupDataAccessInterface, MatchLookupDataAccessInterface {
 
 	private UserFactory userFactory;
 	private MatchFactory matchFactory;
@@ -76,9 +77,7 @@ public class APIDataAccessObject implements UserLookupDataAccessInterface, Brawl
 		try {
 			final Response response = client.newCall(request).execute();
 			final JSONObject responseBody = new JSONObject(response.body().string());
-			System.out.println(responseBody);
 			final JSONArray matches = responseBody.getJSONArray("items");
-			System.out.println(matches.toString());
 			List<Match> matchList = new ArrayList<>();
 			for (int i = 0; i < matches.length(); i++) {
 				matchList.add(extractMatchData(matches, i));

--- a/src/main/java/data_access/APIDataAccessObject.java
+++ b/src/main/java/data_access/APIDataAccessObject.java
@@ -1,7 +1,13 @@
 package data_access;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
+import entity.Match;
+import entity.MatchFactory;
+import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import entity.UserFactory;
@@ -16,17 +22,23 @@ import use_case.brawler_lookup.BrawlerLookupDataAccessInterface;
 public class APIDataAccessObject implements UserLookupDataAccessInterface, BrawlerLookupDataAccessInterface {
 
 	private UserFactory userFactory;
+	private MatchFactory matchFactory;
 
 	public APIDataAccessObject(UserFactory userFactory) {
 		this.userFactory = userFactory;
+	}
+
+	public APIDataAccessObject(MatchFactory matchFactory) {
+		this.matchFactory = matchFactory;
 	}
 
 	@Override
 	public User getUser(String tag) {
 
 		Dotenv dotenv = Dotenv.load();
+		String prettyTag = tag.replace("#", "%23");
 
-		final String url = "https://api.brawlstars.com/v1/players/" + tag;
+		final String url = "https://api.brawlstars.com/v1/players/" + prettyTag;
 		final String key = dotenv.get("API_KEY");
 
 		final OkHttpClient client = new OkHttpClient().newBuilder().build();
@@ -46,5 +58,51 @@ public class APIDataAccessObject implements UserLookupDataAccessInterface, Brawl
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	public List<Match> getMatches(String tag) {
+		Dotenv dotenv = Dotenv.load();
+
+		String prettyTag = tag.replace("#", "%23");
+		final String key = dotenv.get("API_KEY");
+		final String url = "https://api.brawlstars.com/v1/players/" + prettyTag + "/battlelog";
+		final OkHttpClient client = new OkHttpClient().newBuilder().build();
+		final Request request = new Request.Builder()
+				.url(url)
+				.addHeader("Authorization", key)
+				.get()
+				.build();
+
+		try {
+			final Response response = client.newCall(request).execute();
+			final JSONObject responseBody = new JSONObject(response.body().string());
+			System.out.println(responseBody);
+			final JSONArray matches = responseBody.getJSONArray("items");
+			System.out.println(matches.toString());
+			List<Match> matchList = new ArrayList<>();
+			for (int i = 0; i < matches.length(); i++) {
+				matchList.add(extractMatchData(matches, i));
+			}
+
+			return matchList;
+
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private Match extractMatchData(JSONArray matches, int i) {
+		int trophyChange;
+		JSONObject currMatch = matches.getJSONObject(i);
+		JSONObject event = currMatch.getJSONObject("event");
+		JSONObject battle = currMatch.getJSONObject("battle");
+		JSONObject starPlayer = battle.getJSONObject("starPlayer");
+
+		try {
+			trophyChange = battle.optInt("trophyChange");
+		} catch (JSONException e) {
+			trophyChange = 0;
+		}
+		return matchFactory.create(currMatch.getString("battleTime"), event.getString("mode"), event.getString("map"), battle.getString("result").equals("victory"), trophyChange, starPlayer.getString("name"), 0);
 	}
 }

--- a/src/main/java/data_access/APIDataAccessObject.java
+++ b/src/main/java/data_access/APIDataAccessObject.java
@@ -51,9 +51,7 @@ public class APIDataAccessObject implements UserLookupDataAccessInterface, Brawl
 
 		try {
 			final Response response = client.newCall(request).execute();
-			System.out.println(response);
 			final JSONObject responseBody = new JSONObject(response.body().string());
-			System.out.println(responseBody.toString());
 			return userFactory.create(responseBody.getString("name"), responseBody.getInt("trophies"));
 
 		} catch (IOException e) {

--- a/src/main/java/entity/Match.java
+++ b/src/main/java/entity/Match.java
@@ -1,5 +1,50 @@
 package entity;
 
-public interface Match {
-    
+public class Match {
+
+    private final String time;
+    private final String mode;
+    private final String map;
+    private final boolean result;
+    private final int trophyChange;
+    private final String starPlayer;
+    private final int trophyCount;
+
+    public Match(String time, String mode, String map, boolean result, int trophyChange, String starPlayer, int trophyCount) {
+        this.time = time;
+        this.mode = mode;
+        this.map = map;
+        this.result = result;
+        this.trophyChange = trophyChange;
+        this.starPlayer = starPlayer;
+        this.trophyCount = trophyCount;
+    }
+
+    public String getTime() {
+        return time;
+    }
+
+    public String getMode() {
+        return mode;
+    }
+
+    public String getMap() {
+        return map;
+    }
+
+    public boolean isVictory() {
+        return result;
+    }
+
+    public int getTrophyChange() {
+        return trophyChange;
+    }
+
+    public String getStarPlayer() {
+        return starPlayer;
+    }
+
+    public int getTrophyCount() {
+        return trophyCount;
+    }
 }

--- a/src/main/java/entity/Match.java
+++ b/src/main/java/entity/Match.java
@@ -47,4 +47,17 @@ public class Match {
     public int getTrophyCount() {
         return trophyCount;
     }
+
+    @Override
+    public String toString() {
+        return "Match{" +
+                "time='" + time + '\'' +
+                ", mode='" + mode + '\'' +
+                ", map='" + map + '\'' +
+                ", result=" + result +
+                ", trophyChange=" + trophyChange +
+                ", starPlayer='" + starPlayer + '\'' +
+                ", trophyCount=" + trophyCount +
+                '}';
+    }
 }

--- a/src/main/java/entity/MatchFactory.java
+++ b/src/main/java/entity/MatchFactory.java
@@ -1,5 +1,7 @@
 package entity;
 
 public class MatchFactory {
-    
+    public Match create(String time, String mode, String map, boolean result, int trophyChange, String starPlayer, int trophyCount) {
+        return new Match(time, mode, map, result, trophyChange, starPlayer, trophyCount);
+    }
 }

--- a/src/main/java/interface_adapter/match_lookup/MatchLookupController.java
+++ b/src/main/java/interface_adapter/match_lookup/MatchLookupController.java
@@ -1,5 +1,20 @@
 package interface_adapter.match_lookup;
 
+import use_case.match_lookup.MatchLookupInputBoundary;
+import use_case.match_lookup.MatchLookupInputData;
+
 public class MatchLookupController {
+
+    private final MatchLookupInputBoundary interactor;
+
+    public MatchLookupController(MatchLookupInputBoundary interactor) {
+        this.interactor = interactor;
+    }
+
+    public void execute(String tag) {
+        final MatchLookupInputData inputData = new MatchLookupInputData(tag);
+
+        interactor.execute(inputData);
+    }
     
 }

--- a/src/main/java/interface_adapter/match_lookup/MatchLookupPresenter.java
+++ b/src/main/java/interface_adapter/match_lookup/MatchLookupPresenter.java
@@ -1,7 +1,5 @@
 package interface_adapter.match_lookup;
 
-import use_case.match_lookup.MatchLookupOutputBoundary;
-
-public class MatchLookupPresenter implements MatchLookupOutputBoundary{
+public class MatchLookupPresenter {
     
 }

--- a/src/main/java/interface_adapter/match_lookup/MatchLookupPresenter.java
+++ b/src/main/java/interface_adapter/match_lookup/MatchLookupPresenter.java
@@ -1,5 +1,31 @@
 package interface_adapter.match_lookup;
 
-public class MatchLookupPresenter {
+import interface_adapter.ViewManagerModel;
+import use_case.match_lookup.MatchLookupOutputBoundary;
+import use_case.match_lookup.MatchLookupOutputData;
+
+
+public class MatchLookupPresenter implements MatchLookupOutputBoundary {
+
+    private final MatchLookupViewModel matchViewModel;
+    private final ViewManagerModel viewManagerModel;
+
+    public MatchLookupPresenter(MatchLookupViewModel matchViewModel, ViewManagerModel viewModelManager) {
+        this.matchViewModel = matchViewModel;
+        this.viewManagerModel = viewModelManager;
+    }
+
+    public void prepareSuccessView(MatchLookupOutputData outputData) {
+        final MatchLookupState state = matchViewModel.getState();
+        state.setMatches(outputData.getMatches());
+
+        matchViewModel.firePropertyChanged();
+        this.viewManagerModel.setState(matchViewModel.getViewName());
+        this.viewManagerModel.firePropertyChanged();
+    }
+
+    public void prepareFailView(String errorMessage) {
+        throw new UnsupportedOperationException(errorMessage);
+    }
     
 }

--- a/src/main/java/interface_adapter/match_lookup/MatchLookupState.java
+++ b/src/main/java/interface_adapter/match_lookup/MatchLookupState.java
@@ -1,5 +1,19 @@
 package interface_adapter.match_lookup;
 
+import entity.Match;
+
+import java.util.List;
+
 public class MatchLookupState {
+
+    private List<Match> matches;
     
+    public List<Match> getMatches() {
+        return matches;
+    }
+
+    public void setMatches(List<Match> matches) {
+        this.matches = matches;
+    }
+
 }

--- a/src/main/java/interface_adapter/match_lookup/MatchLookupViewModel.java
+++ b/src/main/java/interface_adapter/match_lookup/MatchLookupViewModel.java
@@ -5,5 +5,6 @@ import interface_adapter.ViewModel;
 public class MatchLookupViewModel extends ViewModel<MatchLookupState> {
     public MatchLookupViewModel() {
         super("match lookup");
+        this.setState(new MatchLookupState());
     }
 }

--- a/src/main/java/interface_adapter/user_lookup/UserLookupPresenter.java
+++ b/src/main/java/interface_adapter/user_lookup/UserLookupPresenter.java
@@ -27,8 +27,7 @@ public class UserLookupPresenter implements UserLookupOutputBoundary {
 
     @Override
     public void prepareFailView(String errorMessage) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'prepareErrorBoundary'");
+        throw new UnsupportedOperationException(errorMessage);
     }
 
 }

--- a/src/main/java/use_case/match_lookup/MatchLookupDataAccessInterface.java
+++ b/src/main/java/use_case/match_lookup/MatchLookupDataAccessInterface.java
@@ -2,6 +2,8 @@ package use_case.match_lookup;
 
 import entity.Match;
 
+import java.util.List;
+
 public interface MatchLookupDataAccessInterface {
-    Match getMatch(String tag);
+    List<Match> getMatches(String tag);
 }

--- a/src/main/java/use_case/match_lookup/MatchLookupDataAccessInterface.java
+++ b/src/main/java/use_case/match_lookup/MatchLookupDataAccessInterface.java
@@ -1,5 +1,7 @@
 package use_case.match_lookup;
 
+import entity.Match;
+
 public interface MatchLookupDataAccessInterface {
-    
+    Match getMatch(String tag);
 }

--- a/src/main/java/use_case/match_lookup/MatchLookupInputBoundary.java
+++ b/src/main/java/use_case/match_lookup/MatchLookupInputBoundary.java
@@ -2,4 +2,6 @@ package use_case.match_lookup;
 
 public interface MatchLookupInputBoundary {
 
+    void execute(MatchLookupInputData matchLookupInputData);
+
 }

--- a/src/main/java/use_case/match_lookup/MatchLookupInputData.java
+++ b/src/main/java/use_case/match_lookup/MatchLookupInputData.java
@@ -1,5 +1,15 @@
 package use_case.match_lookup;
 
 public class MatchLookupInputData {
-    
+
+    private final String tag;
+
+    public MatchLookupInputData(String tag) {
+        this.tag = tag;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
 }

--- a/src/main/java/use_case/match_lookup/MatchLookupInteractor.java
+++ b/src/main/java/use_case/match_lookup/MatchLookupInteractor.java
@@ -2,6 +2,8 @@ package use_case.match_lookup;
 
 import entity.Match;
 
+import java.util.List;
+
 public class MatchLookupInteractor implements MatchLookupInputBoundary{
 
     private final MatchLookupDataAccessInterface matchLookupDataAccessInterface;
@@ -14,8 +16,8 @@ public class MatchLookupInteractor implements MatchLookupInputBoundary{
 
     public void execute(MatchLookupInputData matchLookupInputData) {
         try {
-            Match match = matchLookupDataAccessInterface.getMatch(matchLookupInputData.getTag());
-            final MatchLookupOutputData matchLookupOutputData = new MatchLookupOutputData(match.getTime(), match.getMode(), match.getMap(), match.isVictory(), match.getTrophyChange(), match.getStarPlayer(), match.getTrophyCount());
+            List<Match> matches = matchLookupDataAccessInterface.getMatches(matchLookupInputData.getTag());
+            final MatchLookupOutputData matchLookupOutputData = new MatchLookupOutputData(matches);
             matchLookupOutputBoundary.prepareSuccessView(matchLookupOutputData);
 
         } catch (RuntimeException e) {

--- a/src/main/java/use_case/match_lookup/MatchLookupInteractor.java
+++ b/src/main/java/use_case/match_lookup/MatchLookupInteractor.java
@@ -1,5 +1,27 @@
 package use_case.match_lookup;
 
+import entity.Match;
+
 public class MatchLookupInteractor implements MatchLookupInputBoundary{
-    
+
+    private final MatchLookupDataAccessInterface matchLookupDataAccessInterface;
+    private final MatchLookupOutputBoundary matchLookupOutputBoundary;
+
+    public MatchLookupInteractor(MatchLookupDataAccessInterface matchLookupDataAccessInterface, MatchLookupOutputBoundary matchLookupOutputBoundary) {
+        this.matchLookupDataAccessInterface = matchLookupDataAccessInterface;
+        this.matchLookupOutputBoundary = matchLookupOutputBoundary;
+    }
+
+    public void execute(MatchLookupInputData matchLookupInputData) {
+        try {
+            Match match = matchLookupDataAccessInterface.getMatch(matchLookupInputData.getTag());
+            final MatchLookupOutputData matchLookupOutputData = new MatchLookupOutputData(match.getTime(), match.getMode(), match.getMap(), match.isVictory(), match.getTrophyChange(), match.getStarPlayer(), match.getTrophyCount());
+            matchLookupOutputBoundary.prepareSuccessView(matchLookupOutputData);
+
+        } catch (RuntimeException e) {
+            matchLookupOutputBoundary.prepareFailView(e.getMessage());
+        }
+    }
+
+
 }

--- a/src/main/java/use_case/match_lookup/MatchLookupOutputBoundary.java
+++ b/src/main/java/use_case/match_lookup/MatchLookupOutputBoundary.java
@@ -1,5 +1,7 @@
 package use_case.match_lookup;
 
 public interface MatchLookupOutputBoundary {
-    
+    void prepareSuccessView(MatchLookupOutputData outputData);
+
+    void prepareFailView(String errorMessage);
 }

--- a/src/main/java/use_case/match_lookup/MatchLookupOutputData.java
+++ b/src/main/java/use_case/match_lookup/MatchLookupOutputData.java
@@ -1,5 +1,50 @@
 package use_case.match_lookup;
 
 public class MatchLookupOutputData {
-    
+
+    private final String time;
+    private final String mode;
+    private final String map;
+    private final boolean victory;
+    private final int trophyChange;
+    private final String starPlayer;
+    private final int trophyCount;
+
+    public MatchLookupOutputData(String time, String mode, String map, boolean result, int trophyChange, String starPlayer, int trophyCount) {
+        this.time = time;
+        this.mode = mode;
+        this.map = map;
+        this.victory = result;
+        this.trophyChange = trophyChange;
+        this.starPlayer = starPlayer;
+        this.trophyCount = trophyCount;
+    }
+
+    public String getTime() {
+        return time;
+    }
+
+    public String getMode() {
+        return mode;
+    }
+
+    public String getMap() {
+        return map;
+    }
+
+    public boolean isVictory() {
+        return victory;
+    }
+
+    public int getTrophyChange() {
+        return trophyChange;
+    }
+
+    public String getStarPlayer() {
+        return starPlayer;
+    }
+
+    public int getTrophyCount() {
+        return trophyCount;
+    }
 }

--- a/src/main/java/use_case/match_lookup/MatchLookupOutputData.java
+++ b/src/main/java/use_case/match_lookup/MatchLookupOutputData.java
@@ -1,50 +1,18 @@
 package use_case.match_lookup;
 
+import entity.Match;
+
+import java.util.List;
+
 public class MatchLookupOutputData {
 
-    private final String time;
-    private final String mode;
-    private final String map;
-    private final boolean victory;
-    private final int trophyChange;
-    private final String starPlayer;
-    private final int trophyCount;
+    private final List<Match> matches;
 
-    public MatchLookupOutputData(String time, String mode, String map, boolean result, int trophyChange, String starPlayer, int trophyCount) {
-        this.time = time;
-        this.mode = mode;
-        this.map = map;
-        this.victory = result;
-        this.trophyChange = trophyChange;
-        this.starPlayer = starPlayer;
-        this.trophyCount = trophyCount;
+    public MatchLookupOutputData(List<Match> matches) {
+        this.matches = matches;
     }
 
-    public String getTime() {
-        return time;
-    }
-
-    public String getMode() {
-        return mode;
-    }
-
-    public String getMap() {
-        return map;
-    }
-
-    public boolean isVictory() {
-        return victory;
-    }
-
-    public int getTrophyChange() {
-        return trophyChange;
-    }
-
-    public String getStarPlayer() {
-        return starPlayer;
-    }
-
-    public int getTrophyCount() {
-        return trophyCount;
+    public List<Match> getMatches() {
+        return matches;
     }
 }

--- a/src/main/java/view/MatchView.java
+++ b/src/main/java/view/MatchView.java
@@ -1,16 +1,100 @@
 package view;
 
+import interface_adapter.ViewManagerModel;
+import interface_adapter.match_lookup.MatchLookupState;
+import interface_adapter.match_lookup.MatchLookupViewModel;
+
+import java.util.List;
+import entity.Match;
+
+import java.awt.Color;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
-import javax.swing.JPanel;
+import javax.swing.*;
 
 public class MatchView extends JPanel implements PropertyChangeListener{
 
+    private final String viewName = "match lookup";
+    private final MatchLookupViewModel viewModel;
+    private final ViewManagerModel viewManagerModel;
+
+    private final JLabel title;
+    private final JButton backButton;
+
+    public MatchView(MatchLookupViewModel viewModel, ViewManagerModel viewManagerModel) {
+        super();
+        this.viewModel = viewModel;
+        this.viewManagerModel = viewManagerModel;
+        viewModel.addPropertyChangeListener(this);
+
+        title = new JLabel("Match Lookup\n");
+        title.setAlignmentX(CENTER_ALIGNMENT);
+
+        backButton = new JButton("Back");
+
+        backButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                viewManagerModel.setState("search");
+                viewManagerModel.firePropertyChanged();
+            }
+        });
+
+        this.setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+
+        this.add(title);
+        this.add(backButton);
+
+    }
+
+
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'propertyChange'");
+        final MatchLookupState state = (MatchLookupState) evt.getNewValue();
+
+        List<Match> matches = state.getMatches();
+        for (Match match : matches) {
+            /* 
+             * Create a JPanel for each match and add it to the view
+             * each JPanel should look like this:
+             * Result    MatchTime (convert from YYYYMMDDTHHMMSSZ to MM/DD/YYYY)
+             * Mode   Map  
+             * Trophy Change:               Star Player: 
+             */
+            JPanel matchPanel = new JPanel();
+            matchPanel.setLayout(new BoxLayout(matchPanel, BoxLayout.X_AXIS));
+            JLabel result = new JLabel (match.isVictory() ? "Victory" : "Defeat ");
+            result.setForeground(match.isVictory() ? Color.BLUE : Color.RED);
+            String time = match.getTime();
+            String fmtTime = time.substring(4, 6) + "/" + time.substring(6, 8) + "/" + time.substring(0, 4) + " " + time.substring(9, 11) + ":" + time.substring(11, 13);
+            JLabel matchTime = new JLabel(fmtTime);
+            JLabel mode = new JLabel(match.getMode());
+            JLabel map = new JLabel(match.getMap());
+            int trophyChange = match.getTrophyChange();
+            JLabel trophyChangeLabel = new JLabel(trophyChange > 0 ? "+" + trophyChange : "" + trophyChange);
+            JLabel starPlayer = new JLabel("Star Player: " + match.getStarPlayer());
+            matchPanel.add(result);
+            matchPanel.add(Box.createHorizontalStrut(10));
+            matchPanel.add(trophyChangeLabel);
+            matchPanel.add(Box.createHorizontalStrut(10));
+            matchPanel.add(matchTime);
+            matchPanel.add(Box.createHorizontalStrut(10));
+            matchPanel.add(mode);
+            matchPanel.add(Box.createHorizontalStrut(10));
+            matchPanel.add(map);
+            matchPanel.add(Box.createHorizontalStrut(10));
+            matchPanel.add(starPlayer);
+            matchPanel.add(Box.createVerticalStrut(10));
+            this.add(matchPanel);
+        }
+        
+
     }
-    
+
+    public String getViewName() {
+        return viewName;
+    }
 }

--- a/src/main/java/view/SearchView.java
+++ b/src/main/java/view/SearchView.java
@@ -18,7 +18,7 @@ import javax.swing.event.DocumentListener;
 
 public class SearchView extends JPanel implements PropertyChangeListener {
 
-    private final String viewName = "Search";
+    private final String viewName = "search";
     private final SearchViewModel searchViewModel;
 
     private final JTextField searchField = new JTextField();
@@ -33,13 +33,14 @@ public class SearchView extends JPanel implements PropertyChangeListener {
     private MatchLookupController matchLookupController;
 
     public SearchView(SearchViewModel viewModel, BrawlerLookupController brawlerLookupController,
-            UserLookupController userLookupController) {
+            UserLookupController userLookupController, MatchLookupController matchLookupController) {
         this.searchViewModel = viewModel;
         this.searchViewModel.addPropertyChangeListener(this);
         this.brawlerLookupController = brawlerLookupController;
         this.userLookupController = userLookupController;
+        this.matchLookupController = matchLookupController;
 
-        final JLabel title = new JLabel("Search");
+        final JLabel title = new JLabel("Player Tag:");
         title.setAlignmentX(JComponent.CENTER_ALIGNMENT);
 
         searchField.setPreferredSize(new Dimension(200, searchField.getPreferredSize().height));
@@ -86,7 +87,7 @@ public class SearchView extends JPanel implements PropertyChangeListener {
                         }
                     }
                 }
-        )
+        );
 
         searchField.getDocument().addDocumentListener(new DocumentListener() {
 

--- a/src/main/java/view/SearchView.java
+++ b/src/main/java/view/SearchView.java
@@ -1,6 +1,7 @@
 package view;
 
 import interface_adapter.brawler_lookup.BrawlerLookupController;
+import interface_adapter.match_lookup.MatchLookupController;
 import interface_adapter.search.SearchState;
 import interface_adapter.search.SearchViewModel;
 import interface_adapter.user_lookup.UserLookupController;
@@ -25,9 +26,11 @@ public class SearchView extends JPanel implements PropertyChangeListener {
 
     private final JButton searchBrawlerButton;
     private final JButton searchPlayerButton;
+    private final JButton searchMatchButton;
 
     private BrawlerLookupController brawlerLookupController;
     private UserLookupController userLookupController;
+    private MatchLookupController matchLookupController;
 
     public SearchView(SearchViewModel viewModel, BrawlerLookupController brawlerLookupController,
             UserLookupController userLookupController) {
@@ -45,8 +48,11 @@ public class SearchView extends JPanel implements PropertyChangeListener {
         final JPanel buttons = new JPanel();
         searchBrawlerButton = new JButton("Search Brawler");
         searchPlayerButton = new JButton("Search Player");
+        searchMatchButton = new JButton("Search Match");
+
         buttons.add(searchBrawlerButton);
         buttons.add(searchPlayerButton);
+        buttons.add(searchMatchButton);
 
         searchBrawlerButton.addActionListener(
                 new ActionListener() {
@@ -69,6 +75,18 @@ public class SearchView extends JPanel implements PropertyChangeListener {
                         }
                     }
                 });
+
+        searchMatchButton.addActionListener(
+                new ActionListener() {
+                    public void actionPerformed(ActionEvent e) {
+                        if (e.getSource().equals(searchMatchButton)) {
+                            final SearchState currentMatchLookupState = searchViewModel.getState();
+
+                            matchLookupController.execute(currentMatchLookupState.getQuery());
+                        }
+                    }
+                }
+        )
 
         searchField.getDocument().addDocumentListener(new DocumentListener() {
 

--- a/src/test/java/use_case/fetch_battle_log/GetMatchesTest.java
+++ b/src/test/java/use_case/fetch_battle_log/GetMatchesTest.java
@@ -1,0 +1,15 @@
+package use_case.fetch_battle_log;
+
+import data_access.APIDataAccessObject;
+import entity.MatchFactory;
+import org.junit.Test;
+
+public class GetMatchesTest {
+
+    @Test
+    public void getMatchesTest(){
+        APIDataAccessObject api = new APIDataAccessObject(new MatchFactory());
+        api.getMatches("#99uv0990");
+    }
+
+}

--- a/src/test/java/use_case/fetch_user/GetUserTest.java
+++ b/src/test/java/use_case/fetch_user/GetUserTest.java
@@ -10,7 +10,7 @@ public class GetUserTest {
 	@Test
 	public void getUserSuccessTest() {
 		APIDataAccessObject api = new APIDataAccessObject(new UserFactory());
-		api.getUser("%23822GY0JYY");
+		api.getUser("#822GY0JYY");
 	}
 
 }


### PR DESCRIPTION
Added the ability to check a user's recent performance. This feature can be accessed through a new button on the Search page. The performance data includes data about their recent matches, including:
* the time the match took place
* the result of the match
* the trophy change (skill rating change) as a result of the match
* the match mode
* the match map
* the star player (who the game thought was the most impactful player)

Users can now also search for tags including the string "#", as previously the usage of "#" in the search query would result in a 404 error. 